### PR TITLE
reflect-seek-in-player #comment raise VideoSeeked from SeekVideo comm…

### DIFF
--- a/OpenCast/app/service/player.py
+++ b/OpenCast/app/service/player.py
@@ -71,8 +71,11 @@ class PlayerService(Service):
         self._update(cmd.id, impl)
 
     def _seek_video(self, cmd):
-        self._player.seek(cmd.duration)
-        # TODO reflect change in model
+        def impl(model):
+            model.seek_video()
+            self._player.seek(cmd.duration)
+
+        self._update(cmd.id, impl)
 
     def _update_volume(self, cmd):
         def impl(model):

--- a/OpenCast/domain/model/player.py
+++ b/OpenCast/domain/model/player.py
@@ -123,6 +123,14 @@ class Player(Entity):
             raise DomainError(f"unknown video: {video_id}")
         self._record(Evt.VideoRemoved, video_id)
 
+    def next_video(self):
+        if self._index + 1 >= len(self._queue):
+            if self._queue and config["player.loop_last"] is True:
+                return self._queue[self._index].id
+            return None
+
+        return self._queue[self._index + 1].id
+
     def toggle_pause(self):
         if self._state is State.PLAYING:
             self._state = State.PAUSED
@@ -132,13 +140,7 @@ class Player(Entity):
             raise DomainError("the player is not started")
         self._record(Evt.PlayerStateToggled)
 
-    def next_video(self):
-        if self._index + 1 >= len(self._queue):
-            if self._queue and config["player.loop_last"] is True:
-                return self._queue[self._index].id
-            return None
-
-        return self._queue[self._index + 1].id
-
     def seek_video(self):
+        if self._state is State.STOPPED:
+            raise DomainError("the player is not started")
         self._record(Evt.VideoSeeked)

--- a/test/integration/app/service/test_player.py
+++ b/test/integration/app/service/test_player.py
@@ -80,6 +80,22 @@ class PlayerServiceTest(ServiceTestCase):
             Cmd.TogglePlayerState, self.player_id
         )
 
+    def test_seek_video(self):
+        self.data_producer.player().video("source", None).play().populate(
+            self.data_facade
+        )
+
+        self.evt_expecter.expect(Evt.VideoSeeked, self.player_id).from_(
+            Cmd.SeekVideo, self.player_id, 1
+        )
+
+    def test_seek_video_not_started(self):
+        self.data_producer.player().video("source", None).populate(self.data_facade)
+
+        self.evt_expecter.expect(OperationError, "the player is not started").from_(
+            Cmd.SeekVideo, self.player_id, 1
+        )
+
     def test_change_video_volume(self):
         self.data_producer.player().video("source", None).play().populate(
             self.data_facade

--- a/test/unit/domain/model/test_player.py
+++ b/test/unit/domain/model/test_player.py
@@ -98,10 +98,10 @@ class PlayerTest(ModelTestCase):
         self.assertTrue(self.player.has_video(video.id))
 
     def test_next(self):
+        config.load_from_dict({"player": {"loop_last": False}})
         videos = self.make_videos(video_count=2)
         for video in videos:
             self.player.queue(video)
-        config.load_from_dict({"player": {"loop_last": False}})
         self.assertEqual(videos[1].id, self.player.next_video())
         self.assertEqual(videos[1].id, self.player.next_video())
 
@@ -111,8 +111,24 @@ class PlayerTest(ModelTestCase):
         self.assertEqual(None, self.player.next_video())
 
     def test_next_no_video(self):
+        config.load_from_dict({"player": {"loop_last": False}})
+        self.assertEqual(None, self.player.next_video())
+
+    def test_next_no_video_loop_last(self):
         config.load_from_dict({"player": {"loop_last": True}})
         self.assertEqual(None, self.player.next_video())
+
+    def test_next_last_video(self):
+        config.load_from_dict({"player": {"loop_last": False}})
+        video = self.make_video()
+        self.player.queue(video)
+        self.assertEqual(None, self.player.next_video())
+
+    def test_next_last_video_loop_last(self):
+        config.load_from_dict({"player": {"loop_last": True}})
+        video = self.make_video()
+        self.player.queue(video)
+        self.assertEqual(video.id, self.player.next_video())
 
     def test_toggle_pause(self):
         video = self.make_video()

--- a/test/unit/domain/model/test_player.py
+++ b/test/unit/domain/model/test_player.py
@@ -156,3 +156,17 @@ class PlayerTest(ModelTestCase):
         self.expect_events(
             self.player, Evt.VolumeUpdated, Evt.VolumeUpdated, Evt.VolumeUpdated
         )
+
+    def test_seek_video(self):
+        video = self.make_video()
+        self.player.queue(video)
+        self.player.play(video)
+        self.player.seek_video()
+        self.expect_events(
+            self.player, Evt.VideoQueued, Evt.PlayerStarted, Evt.VideoSeeked
+        )
+
+    def test_seek_video_not_started(self):
+        with self.assertRaises(DomainError) as ctx:
+            self.player.seek_video()
+        self.assertEqual("the player is not started", str(ctx.exception))


### PR DESCRIPTION
…and.

 - Fix the deadlock occuring in the player monitor controller when sending a seek request.
 - Keep the domain stateless regarding video time.
 - Add tests.