### PR TITLE
require-ffmpeg #comment Add --ci parameter to setup script.

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           python-version: "3.8"
       - name: Install dependencies
-        run: ./setup.sh
+        run: ./setup.sh --ci
       #
       - name: Generate documentation
         run: ./OpenCast.sh gen doc

--- a/.github/workflows/sanitize.yml
+++ b/.github/workflows/sanitize.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       #
       - name: Install dependencies
-        run: ./setup.sh
+        run: ./setup.sh --ci
       #
       - name: Lint
         run: ./OpenCast.sh lint all

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       #
       - name: Install dependencies
-        run: ./setup.sh
+        run: ./setup.sh --ci
       #
       - name: Test
         run: ./OpenCast.sh test all --coverage

--- a/script/cli_builder.sh
+++ b/script/cli_builder.sh
@@ -127,7 +127,10 @@ decay() {
 }
 
 display_help() {
-  printf "usage: %s" "$command"
+  local script_name
+
+  script_name="$(basename "$0")"
+  printf "usage: %s %s" "$script_name" "$command"
   for param in "${params_ref[@]}"; do
     printf " %s" "$param"
   done


### PR DESCRIPTION
 - The new parameter adds expectations for vlc and ffmpeg dependencies which are mocked during tests.