### PR TITLE
improve-bash-arg-parsing #comment Rewrite the script CLI builder.

### DIFF
--- a/OpenCast.sh
+++ b/OpenCast.sh
@@ -1,45 +1,20 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./OpenCast.sh command [<args>...]
+#
+# Commands:
+#   format   Run formatters on the source code.
+#   generate Generate content.
+#   lint     Lint the source code.
+#   serve    Serve static web pages.
+#   service  Operate services.
+#   test     Run the tests.
 
-PROJECT_DIR="$(cd "$(dirname "$0")" && pwd)"
+ROOT="$(cd "$(dirname "$0")" && pwd)"
 
 # shellcheck source=script/cli_builder.sh
-source "$PROJECT_DIR/script/cli_builder.sh"
+source "$ROOT/script/cli_builder.sh"
 
-#### CLI handlers
-
-format() {
-  "$PROJECT_DIR/tool/format.sh" "$@"
-}
-
-gen() {
-  "$PROJECT_DIR/tool/generate.sh" "$@"
-}
-
-lint() {
-  "$PROJECT_DIR/tool/lint.sh" "$@"
-}
-
-serve() {
-  "$PROJECT_DIR/tool/serve.sh" "$@"
-}
-
-service() {
-  "$PROJECT_DIR/tool/service.sh" "$@"
-}
-
-test() {
-  "$PROJECT_DIR/tool/test.sh" "$@"
-}
-
-#### CLI definition
-
-declare -A COMMANDS
-export COMMANDS=(
-  [format]="Format source code."
-  [gen]="Generate content."
-  [lint]="Run linters on given targets."
-  [serve]="Serve static web pages."
-  [service]="Operate services."
-  [test]="Run the test suite of a service."
-)
-make_cli default_help_display COMMANDS "$@"
+parse_args "$@"
+IFS=";" read -r -a arguments <<<"${ARGS["args"]}"
+"$ROOT/tool/${ARGS["command"]}.sh" "${arguments[@]}"

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -28,5 +28,7 @@ require_shfmt() {
     local dest="/usr/local/bin/shfmt"
     sudo wget -q "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_amd64" -O "$dest"
     sudo chmod +x "$dest"
+
+    log_info "shfmt is installed in /usr/local/bin"
   fi
 }

--- a/script/deps.sh
+++ b/script/deps.sh
@@ -16,6 +16,8 @@ require_shellcheck() {
     wget -qO- "https://github.com/koalaman/shellcheck/releases/download/${SC_VERSION?}/shellcheck-${SC_VERSION?}.linux.x86_64.tar.xz" | tar -xJv
     sudo cp "shellcheck-${SC_VERSION}/shellcheck" /usr/local/bin/
     rm -rf "shellcheck-${SC_VERSION}"
+
+    log_info "shellcheck is installed in /usr/local/bin"
   fi
 }
 

--- a/tool/format.sh
+++ b/tool/format.sh
@@ -6,6 +6,9 @@
 #   all     Run all formatters.
 #   python  Run formatters on python code.
 #   shell   Run formatters on shell code.
+#
+# Options:
+#   --check  Don't edit files in place.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"

--- a/tool/format.sh
+++ b/tool/format.sh
@@ -22,8 +22,7 @@ source "$ROOT/script/deps.sh"
 #### CLI handlers
 
 all() {
-  python "$@"
-  shell "$@"
+  python "$@" && shell "$@"
 }
 
 python() {
@@ -44,10 +43,14 @@ python() {
     done < <(find "$ROOT/$py_dir" -name "*.py" -print0)
   done
 
+  local black_status isort_status
   penv black "${black_opts[@]}" "${py_files[@]}"
-  log_status "black" "$?"
+  black_status="$?"
+  log_status "black" "$black_status"
   penv isort "${isort_opts[@]}" "${py_files[@]}"
-  log_status "isort" "$?"
+  isort_status="$?"
+  log_status "isort" "$isort_status"
+  return "$((black_status | isort_status))"
 }
 
 shell() {

--- a/tool/format.sh
+++ b/tool/format.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./format.sh command [--check]
+#
+# Commands:
+#   all     Run all formatters.
+#   python  Run formatters on python code.
+#   shell   Run formatters on shell code.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
@@ -20,13 +27,8 @@ all() {
 }
 
 python() {
-  # shellcheck disable=SC2034
-  local -a params=("--check")
-  local -A parsed
-  expect_params params parsed "python" "$@"
-
   local black_opts isort_opts=()
-  if [[ -n "${parsed["--check"]}" ]]; then
+  if [[ "${ARGS["--check"]}" == true ]]; then
     black_opts+=("--check")
     isort_opts+=("--check-only")
   fi
@@ -51,13 +53,8 @@ python() {
 shell() {
   require_shfmt
 
-  # shellcheck disable=SC2034
-  local -a params=("--check")
-  local -A parsed
-  expect_params params parsed "shell" "$@"
-
   local shfmt_opts=("-l" "-d" "-i" "2")
-  [[ -z "${parsed["--check"]}" ]] && shfmt_opts+=("-w")
+  [[ "${ARGS["--check"]}" == false ]] && shfmt_opts+=("-w")
 
   sh_files=()
   sh_dirs=("." "tool" "script")
@@ -74,12 +71,5 @@ shell() {
   log_status "shfmt" "$?"
 }
 
-#### CLI definition
-
-declare -A COMMANDS
-export COMMANDS=(
-  [all]="Run all formatters."
-  [python]="Run formatters on python code."
-  [shell]="Run formatters on shell code."
-)
-make_cli default_help_display COMMANDS "$@"
+parse_args "$@"
+${ARGS["command"]}

--- a/tool/generate.sh
+++ b/tool/generate.sh
@@ -1,4 +1,10 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./generate.sh command
+#
+# Commands:
+#   doc   Generate documentation files.
+#   spec  Generate a merged openapi file.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
@@ -19,11 +25,5 @@ spec() {
   jenv "speccy --config $ROOT/specs/.speccy.yml resolve $ROOT/specs/openapi.yml --output $ROOT/gen/openapi.yml"
 }
 
-#### CLI definition
-
-declare -A COMMANDS
-export COMMANDS=(
-  [doc]="Generate documentation files."
-  [spec]="Generate a merged openapi file."
-)
-make_cli default_help_display COMMANDS "$@"
+parse_args "$@"
+${ARGS["command"]}

--- a/tool/lint.sh
+++ b/tool/lint.sh
@@ -5,7 +5,7 @@
 # Commands:
 #   all     Run all linters.
 #   python  Run the linter on the python code.
-#   shell   Run the shellcheck on scripts.
+#   shell   Run shellcheck on scripts.
 #   spec    Run the linter on the API spec.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"

--- a/tool/lint.sh
+++ b/tool/lint.sh
@@ -23,9 +23,7 @@ source "$ROOT/script/deps.sh"
 #### CLI handlers
 
 all() {
-  python
-  shell
-  spec
+  python && shell && spec
 }
 
 python() {

--- a/tool/lint.sh
+++ b/tool/lint.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./lint.sh command
+#
+# Commands:
+#   all     Run all linters.
+#   python  Run the linter on the python code.
+#   shell   Run the shellcheck on scripts.
+#   spec    Run the linter on the API spec.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
@@ -48,13 +56,5 @@ spec() {
   log_status "speccy" "$?"
 }
 
-#### CLI definition
-
-declare -A COMMANDS
-export COMMANDS=(
-  [all]="Run all linters."
-  [python]="Run the linter on the python code."
-  [shell]="Run the shellcheck on scripts."
-  [spec]="Run the linter on the API spec."
-)
-make_cli default_help_display COMMANDS "$@"
+parse_args "$@"
+${ARGS["command"]}

--- a/tool/serve.sh
+++ b/tool/serve.sh
@@ -1,4 +1,9 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./serve.sh command
+#
+# Commands:
+#   spec  View specifications in beautiful human readable documentation.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
@@ -14,10 +19,5 @@ spec() {
   jenv "speccy --config $ROOT/specs/.speccy.yml serve $ROOT/specs/openapi.yml"
 }
 
-#### CLI definition
-
-declare -A COMMANDS
-export COMMANDS=(
-  [spec]="View specifications in beautiful human readable documentation."
-)
-make_cli default_help_display COMMANDS "$@"
+parse_args "$@"
+${ARGS["command"]}

--- a/tool/service-back.sh
+++ b/tool/service-back.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./service-back.sh command
+#
+# Commands:
+#   log      Tail the log file.
+#   start    Start the service.
+#   stop     Stop the service.
+#   restart  Restart the service.
+#   status   Display the status of the service.
+#   update   Update the dependencies of the service.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
@@ -50,15 +60,5 @@ update() {
   poetry update
 }
 
-#### CLI definition
-
-declare -A COMMANDS
-export COMMANDS=(
-  [log]="Tail the log file."
-  [start]="Start the service."
-  [stop]="Stop the service."
-  [restart]="Restart the service."
-  [status]="Display the status of the service."
-  [update]="Update the dependencies of the service."
-)
-make_cli default_help_display COMMANDS "$@"
+parse_args "$@"
+${ARGS["command"]}

--- a/tool/service-front.sh
+++ b/tool/service-front.sh
@@ -7,6 +7,9 @@
 #   stop     Stop the service.
 #   restart  Restart the service.
 #   status   Display the status of the service.
+#
+# Options:
+#   --dev  Start the service in development mode.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"

--- a/tool/service-front.sh
+++ b/tool/service-front.sh
@@ -1,4 +1,12 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./service-front.sh command [--dev]
+#
+# Commands:
+#   start    Start the service.
+#   stop     Stop the service.
+#   restart  Restart the service.
+#   status   Display the status of the service.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
@@ -16,14 +24,9 @@ source "$ROOT/script/env.sh"
 #### CLI handlers
 
 start() {
-  # shellcheck disable=SC2034
-  local -a params=("--dev")
-  local -A parsed
-  expect_params params parsed "start" "$@"
-
   local npm_cmd
   npm_cmd="WEBAPP_PORT=$WEBAPP_PORT npm run serve &"
-  [[ -n "${parsed["--dev"]}" ]] && npm_cmd="npm start"
+  [[ -n "${ARGS["--dev"]}" ]] && npm_cmd="npm start"
 
   (cd "$WEBAPP_DIR" && eval "$npm_cmd")
 }
@@ -44,13 +47,5 @@ status() {
   log_status "$SERVICE_NAME" "$status"
 }
 
-#### CLI definition
-
-declare -A COMMANDS
-export COMMANDS=(
-  [start]="Start the service."
-  [stop]="Stop the service."
-  [restart]="Restart the service."
-  [status]="Display the status of the service."
-)
-make_cli default_help_display COMMANDS "$@"
+parse_args "$@"
+${ARGS["command"]}

--- a/tool/service.sh
+++ b/tool/service.sh
@@ -1,4 +1,14 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./service.sh command [<args>...]
+#
+# Commands:
+#   back     Command the back-end service.
+#   front    Command the front-end service.
+#   start    Start all services.
+#   stop     Stop all services.
+#   restart  Restart all services.
+#   status   Display the status of all service.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
@@ -38,21 +48,6 @@ status() {
   "$SERVICE_FRONT" "status"
 }
 
-test() {
-  "$SERVICE_BACK" "test" &&
-    "$SERVICE_FRONT" "test"
-}
-
-#### CLI definition
-
-declare -A COMMANDS
-export COMMANDS=(
-  [back]="Back end service."
-  [front]="Front end service."
-  [start]="Start all services."
-  [stop]="Stop all services."
-  [restart]="Restart all services."
-  [status]="Display the status of all service."
-  [test]="Run tests for all services."
-)
-make_cli default_help_display COMMANDS "$@"
+parse_args "$@"
+IFS=";" read -r -a arguments <<<"${ARGS["args"]}"
+${ARGS["command"]} "${arguments[@]}"

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# Usage:
+#   ./test.sh command [<selector>] [--coverage]
+#
+# Commands:
+#   all    Run all tests.
+#   back   Run the test suite of the python application.
+#   front  Run the test suite of the web application.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"
@@ -18,21 +25,16 @@ all() {
 }
 
 back() {
-  # shellcheck disable=SC2034
-  local -a params=("--coverage" "[<selector>]")
-  local -A parsed
-  expect_params params parsed "back" "$@"
-
   local command selector
   command=("python")
   selector="discover"
-  [[ -n "${parsed["--coverage"]}" ]] && command=("coverage" "run")
-  [[ -n "${parsed["selector"]}" ]] && selector="${parsed["selector"]}"
+  [[ "${ARGS["--coverage"]}" == true ]] && command=("coverage" "run")
+  [[ -n "${ARGS["selector"]}" ]] && selector="${ARGS["selector"]}"
 
   penv "${command[@]}" -m unittest "$selector" -v
   log_status "Python" "$?"
 
-  [[ -n "${parsed["--coverage"]}" ]] && penv coverage xml
+  [[ "${ARGS["--coverage"]}" == true ]] && penv coverage xml
 }
 
 front() {
@@ -40,12 +42,5 @@ front() {
   log_status "Webapp" "0"
 }
 
-#### CLI definition
-
-declare -A COMMANDS
-export COMMANDS=(
-  [all]="Run all tests."
-  [back]="Run the test suite of the python application."
-  [front]="Run the test suite of the web application."
-)
-make_cli default_help_display COMMANDS "$@"
+parse_args "$@"
+${ARGS["command"]}

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -20,8 +20,7 @@ source "$ROOT/script/logging.sh"
 #### CLI handlers
 
 all() {
-  back "$@"
-  front "$@"
+  back "$@" && front "$@"
 }
 
 back() {
@@ -32,9 +31,10 @@ back() {
   [[ -n "${ARGS["selector"]}" ]] && selector="${ARGS["selector"]}"
 
   penv "${command[@]}" -m unittest "$selector" -v
-  log_status "Python" "$?"
+  local status="$?"
 
   [[ "${ARGS["--coverage"]}" == true ]] && penv coverage xml
+  log_status "Python" "$status"
 }
 
 front() {

--- a/tool/test.sh
+++ b/tool/test.sh
@@ -6,6 +6,9 @@
 #   all    Run all tests.
 #   back   Run the test suite of the python application.
 #   front  Run the test suite of the web application.
+#
+# Options:
+#   --coverage  Mesure test coverage.
 
 HERE="$(cd "$(dirname "${BASH_SOURCE:-0}")" && pwd)"
 ROOT="$(cd "$HERE/.." && pwd)"


### PR DESCRIPTION
 In an attempt to have a good cli builder I've tried docopts (golang & python) but both have flows and are not maintained
 Prs are not merged and issues keep poping up.
 Docopt is almost usable, but almost is not good enough when nobody works on it.
 This commit tries to comply with docopt spec and focuses and the functionalities required by the project, it works and doesn't add dependencies to a flawed project.

 - Implement at least the same level of functionality as before.
 - Read usage from the file's header and build a parser.

I forgot to add, I've also checked docopt-ng, which might be stable, but also unmaintained ...