### PR TITLE
Load library

### DIFF
--- a/OpenCast/app/controller/player_monitor.py
+++ b/OpenCast/app/controller/player_monitor.py
@@ -49,6 +49,11 @@ class PlayerMonitController(MonitorController):
 
     async def get(self, _):
         player = self._player_repo.get_player()
+
+        # TODO: Remove this quick workaround after the implementation of playlists
+        videos = self._video_repo.list(player.video_queue)
+        player._queue = videos
+
         return self._ok(player)
 
     async def stream(self, req):

--- a/OpenCast/app/workflow/factory.py
+++ b/OpenCast/app/workflow/factory.py
@@ -6,11 +6,15 @@ from .player import (
     StreamPlaylistWorkflow,
     StreamVideoWorkflow,
 )
+from .root import RootWorkflow
 from .video import VideoWorkflow
 
 
 class WorkflowFactory(object):
     """Creates instances of workflows."""
+
+    def make_root_workflow(self, *args, **kwargs):
+        return RootWorkflow(*args, **kwargs)
 
     def make_video_workflow(self, *args, **kwargs):
         return VideoWorkflow(*args, **kwargs)

--- a/OpenCast/app/workflow/manager.py
+++ b/OpenCast/app/workflow/manager.py
@@ -35,6 +35,7 @@ class WorkflowManager:
                 {workflow.Completed: on_completion, workflow.Aborted: on_completion},
                 times=1,
             )
-            self._logger.debug("Starting workflow", workflow=workflow)
-            workflow.start(*args, **kwargs)
-            return True
+
+        self._logger.debug("Starting workflow", workflow=workflow)
+        workflow.start(*args, **kwargs)
+        return True

--- a/OpenCast/app/workflow/root.py
+++ b/OpenCast/app/workflow/root.py
@@ -77,7 +77,7 @@ class RootWorkflow(Workflow):
                 config["server.host"], config["server.port"]
             )
         except Exception as e:
-            self._logger.error(f"Server exception caught", error=e)
+            self._logger.error("Server exception caught", error=e)
             self.to_ABORTED(e)
 
     def on_enter_ABORTED(self, _):

--- a/OpenCast/app/workflow/root.py
+++ b/OpenCast/app/workflow/root.py
@@ -1,0 +1,84 @@
+""" The application's workflow """
+
+from collections import namedtuple
+from enum import Enum, auto
+from pathlib import Path
+
+import structlog
+
+from OpenCast.config import config
+from OpenCast.domain.service.identity import IdentityService
+
+from .video import Video, VideoWorkflow
+from .workflow import Workflow
+
+
+class RootWorkflow(Workflow):
+    Completed = namedtuple("RootWorkflowCompleted", ("id"))
+    Aborted = namedtuple("RootWorkflowAborted", ("id"))
+
+    # fmt: off
+    class States(Enum):
+        INITIAL = auto()
+        LOADING = auto()
+        RUNNING = auto()
+        ABORTED = auto()
+
+    # Trigger - Source - Dest - Conditions - Unless - Before - After - Prepare
+    transitions = [
+        ["start", States.INITIAL, States.LOADING],
+    ]
+    # fmt: on
+
+    def __init__(
+        self,
+        id,
+        app_facade,
+        infra_facade,
+        data_facade,
+    ):
+        logger = structlog.get_logger(__name__)
+        super().__init__(
+            logger,
+            self,
+            id,
+            app_facade,
+            initial=RootWorkflow.States.INITIAL,
+        )
+        self._infra_facade = infra_facade
+        self._data_facade = data_facade
+
+        self._file_service = infra_facade.service_factory.make_file_service()
+
+    # States
+    def on_enter_LOADING(self):
+        # TODO: move this logic in a separate task and spawn a new one from here
+        download_dir = Path(config["downloader.output_directory"])
+        files = self._file_service.list_directory(download_dir, "*")
+        for path in files:
+            if not path.is_file():
+                continue
+            source = str(path)
+            media_id = IdentityService.id_video(source)
+            workflow_id = IdentityService.id_workflow(VideoWorkflow, media_id)
+            workflow = self._factory.make_video_workflow(
+                workflow_id,
+                self._app_facade,
+                self._data_facade.video_repo,
+                Video(media_id, source, None),
+            )
+            self._start_workflow(workflow)
+
+        self.to_RUNNING()
+
+    def on_enter_RUNNING(self):
+        try:
+            self._infra_facade.server.start(
+                config["server.host"], config["server.port"]
+            )
+        except Exception as e:
+            self._logger.error(f"Server exception caught", error=e)
+            self.to_ABORTED(e)
+
+    def on_enter_ABORTED(self, _):
+        self.cancel()

--- a/OpenCast/app/workflow/workflow.py
+++ b/OpenCast/app/workflow/workflow.py
@@ -53,6 +53,7 @@ class Workflow(Machine):
 
     def reset(self):
         """ Reset the workflow and its sub-workflows to their initial state"""
+        # TODO: Remove as unused and incompatible with the workflow manager
         self.set_state(self._initial)
         for workflow in self._sub_workflows:
             workflow.reset()
@@ -66,10 +67,15 @@ class Workflow(Machine):
 
     def _observe_start(self, workflow, *args, **kwargs):
         self._observe(workflow.id, [workflow.Completed, workflow.Aborted])
+        self._start_workflow(workflow, *args, **kwargs)
+
+    def _start_workflow(self, workflow, *args, **kwargs):
         if self._app_facade.workflow_manager.start(workflow, *args, **kwargs):
             self._sub_workflows.append(workflow)
 
     def _observe_dispatch(self, evt_cls, cmd_cls, model_id: Id, *args, **kwargs):
+        # TODO consider using the workflow id for commands from a same workflow
+        # cmd = cmd_cls(self.id, model_id, *args, **kwargs)
         cmd = make_cmd(cmd_cls, model_id, *args, **kwargs)
         self._observe(cmd.id, [evt_cls, OperationError])
         self._cmd_dispatcher.dispatch(cmd)

--- a/OpenCast/domain/service/factory.py
+++ b/OpenCast/domain/service/factory.py
@@ -19,4 +19,4 @@ class ServiceFactory:
         return SourceService(*args)
 
     def make_subtitle_service(self, *args):
-        return SubtitleService(*args)
+        return SubtitleService(self._infra_service_factory.make_file_service(), *args)

--- a/OpenCast/domain/service/identity.py
+++ b/OpenCast/domain/service/identity.py
@@ -9,6 +9,10 @@ class IdentityService:
     PLAYLIST_NS = uuid4()
 
     @staticmethod
+    def random():
+        return uuid4()
+
+    @staticmethod
     def id_workflow(workflow_cls, model_id):
         return uuid3(model_id, workflow_cls.__name__)
 

--- a/OpenCast/domain/service/subtitle.py
+++ b/OpenCast/domain/service/subtitle.py
@@ -6,8 +6,9 @@ import structlog
 
 
 class SubtitleService:
-    def __init__(self, downloader):
+    def __init__(self, file_service, downloader):
         self._logger = structlog.get_logger(__name__)
+        self._file_service = file_service
         self._downloader = downloader
 
     def fetch_subtitle(self, video, language: str, search_online=True) -> Path:
@@ -29,7 +30,7 @@ class SubtitleService:
         parent_path = video_path.parents[0]
         subtitle = str(video_path.with_suffix(".srt"))
         # Find the matching subtitle from a .srt file
-        srtFiles = parent_path.glob("*.srt")
+        srtFiles = self._file_service.list_directory(parent_path, "*.srt")
         if Path(subtitle) in srtFiles:
             self._logger.debug("Found srt file", subtitle=subtitle)
             return subtitle

--- a/OpenCast/infra/data/repo/memory.py
+++ b/OpenCast/infra/data/repo/memory.py
@@ -31,8 +31,10 @@ class MemoryRepo:
         if len(self._table) == prev_size:
             raise RepoError(f"cannot delete: '{model}' doesn't exist")
 
-    def list(self):
-        return deepcopy(self._table)
+    def list(self, ids=None):
+        return deepcopy(
+            self._table if ids is None else [m for m in self._table if m.id in ids]
+        )
 
     def get(self, id_):
         model = next((m for m in self._table if m.id == id_), None)

--- a/OpenCast/infra/facade.py
+++ b/OpenCast/infra/facade.py
@@ -4,9 +4,10 @@ from .io.server import make_server
 
 
 class InfraFacade:
-    def __init__(self, io_factory, media_factory):
+    def __init__(self, io_factory, media_factory, service_factory):
         self._io_factory = io_factory
         self._media_factory = media_factory
+        self._service_factory = service_factory
 
         self._server = make_server()
 
@@ -15,6 +16,10 @@ class InfraFacade:
     @property
     def io_factory(self):
         return self._io_factory
+
+    @property
+    def service_factory(self):
+        return self._service_factory
 
     @property
     def server(self):

--- a/OpenCast/infra/media/parser.py
+++ b/OpenCast/infra/media/parser.py
@@ -41,6 +41,9 @@ class VideoParser:
 
         raise_on_error()
         streams = media.tracks_get()
+        if streams is None:
+            self._logger.error("No stream found", video=video_path)
+            raise VideoParsingError(f"No stream found for '{video_path}'")
 
         type_to_code = {
             TrackType.audio: "audio",

--- a/OpenCast/infra/service/factory.py
+++ b/OpenCast/infra/service/factory.py
@@ -1,2 +1,6 @@
+from .file import FileService
+
+
 class ServiceFactory:
-    pass
+    def make_file_service(self, *args):
+        return FileService()

--- a/OpenCast/infra/service/factory.py
+++ b/OpenCast/infra/service/factory.py
@@ -1,3 +1,6 @@
+""" Factory for creating infra services """
+
+
 from .file import FileService
 
 

--- a/OpenCast/infra/service/file.py
+++ b/OpenCast/infra/service/file.py
@@ -2,6 +2,6 @@ from pathlib import Path
 
 
 class FileService:
-    def list_directory(directory: Path, pattern: str):
+    def list_directory(self, directory: Path, pattern: str):
         files = directory.glob(pattern)
         return [file for file in files if file.is_file()]

--- a/OpenCast/infra/service/file.py
+++ b/OpenCast/infra/service/file.py
@@ -1,3 +1,5 @@
+""" Filesystem operations """
+
 from pathlib import Path
 
 

--- a/OpenCast/infra/service/file.py
+++ b/OpenCast/infra/service/file.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+class FileService:
+    def list_directory(directory: Path, pattern: str):
+        files = directory.glob(pattern)
+        return [file for file in files if file.is_file()]

--- a/test/integration/app/service/test_video.py
+++ b/test/integration/app/service/test_video.py
@@ -118,9 +118,7 @@ class VideoServiceTest(ServiceTestCase):
         # Load from disk
         disk_subtitle = "/tmp/source.srt"
         path_mock.with_suffix.return_value = disk_subtitle
-        parent_mock = Mock()
-        path_mock.parents.__getitem__.return_value = parent_mock
-        parent_mock.glob.return_value = []
+        self.file_service.list_directory.return_value = [Path(disk_subtitle)]
 
         # Download from source
         source_subtitle = "/tmp/source.vtt"

--- a/test/integration/app/service/util.py
+++ b/test/integration/app/service/util.py
@@ -26,16 +26,19 @@ class ServiceTestCase(TestCase):
         self.data_producer = DataProducer.make()
         self.data_producer.player().populate(self.data_facade)
 
-        infraServiceFactory = Mock()
-        self.service_factory = ServiceFactory(infraServiceFactory)
-
         self.downloader = Mock()
         self.video_parser = Mock()
+        self.file_service = Mock()
         self.infra_facade = InfraFacadeMock()
         self.infra_facade.media_factory.make_downloader.return_value = self.downloader
         self.infra_facade.media_factory.make_video_parser.return_value = (
             self.video_parser
         )
+        self.infra_facade.service_factory.make_file_service.return_value = (
+            self.file_service
+        )
+
+        self.service_factory = ServiceFactory(self.infra_facade.service_factory)
 
         self.evt_expecter = EventExpecter(
             self.app_facade.cmd_dispatcher, self.app_facade.evt_dispatcher

--- a/test/shared/infra/facade_mock.py
+++ b/test/shared/infra/facade_mock.py
@@ -7,3 +7,4 @@ class InfraFacadeMock(Mock):
         self.io_factory = Mock()
         self.server = Mock()
         self.media_factory = Mock()
+        self.service_factory = Mock()

--- a/test/unit/app/workflow/test_player.py
+++ b/test/unit/app/workflow/test_player.py
@@ -43,14 +43,14 @@ class QueueVideoWorkflowTest(WorkflowTestCase):
         self.assertTrue(self.workflow.is_COLLECTING())
 
     def test_collecting_to_aborted(self):
-        video_workflow = self.expect_workflow_creation(VideoWorkflow)
+        (video_workflow,) = self.expect_workflow_creation(VideoWorkflow)
         self.workflow.to_COLLECTING()
         video_workflow.start.assert_called_once()
         self.raise_event(self.workflow, video_workflow.Aborted, video_workflow.id)
         self.assertTrue(self.workflow.is_ABORTED())
 
     def test_collecting_to_queueing(self):
-        video_workflow = self.expect_workflow_creation(VideoWorkflow)
+        (video_workflow,) = self.expect_workflow_creation(VideoWorkflow)
         self.workflow.to_COLLECTING()
         video_workflow.start.assert_called_once()
         self.raise_event(self.workflow, video_workflow.Completed, video_workflow.id)
@@ -108,28 +108,28 @@ class QueuePlaylistWorkflowTest(WorkflowTestCase):
 
     def test_queueing_to_queueing_from_completed(self):
         workflow = self.make_test_workflow()
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        queue_workflows = self.expect_workflow_creation(QueueVideoWorkflow, 2)
         workflow.to_QUEUEING(None)
-        self.raise_event(workflow, queue_workflow.Completed, workflow.id)
+        self.raise_event(workflow, queue_workflows[0].Completed, workflow.id)
         self.assertTrue(workflow.is_QUEUEING())
 
     def test_queueing_to_queueing_from_aborted(self):
         workflow = self.make_test_workflow()
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        queue_workflows = self.expect_workflow_creation(QueueVideoWorkflow, 2)
         workflow.to_QUEUEING(None)
-        self.raise_event(workflow, queue_workflow.Aborted, workflow.id)
+        self.raise_event(workflow, queue_workflows[0].Aborted, workflow.id)
         self.assertTrue(workflow.is_QUEUEING())
 
     def test_queueing_to_completed_from_completed(self):
         workflow = self.make_test_workflow(video_count=1)
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        (queue_workflow,) = self.expect_workflow_creation(QueueVideoWorkflow)
         workflow.to_QUEUEING(None)
         self.raise_event(workflow, queue_workflow.Completed, workflow.id)
         self.assertTrue(workflow.is_COMPLETED())
 
     def test_queueing_to_completed_from_aborted(self):
         workflow = self.make_test_workflow(video_count=1)
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        (queue_workflow,) = self.expect_workflow_creation(QueueVideoWorkflow)
         workflow.to_QUEUEING(None)
         self.raise_event(workflow, queue_workflow.Aborted, workflow.id)
         self.assertTrue(workflow.is_COMPLETED())
@@ -162,14 +162,14 @@ class StreamVideoWorkflowTest(WorkflowTestCase):
         self.assertTrue(self.workflow.is_QUEUEING())
 
     def test_queueing_to_aborted(self):
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        (queue_workflow,) = self.expect_workflow_creation(QueueVideoWorkflow)
         self.workflow.to_QUEUEING()
         queue_workflow.start.assert_called_once()
         self.raise_event(self.workflow, queue_workflow.Aborted, queue_workflow.id)
         self.assertTrue(self.workflow.is_ABORTED())
 
     def test_queueing_to_starting(self):
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        (queue_workflow,) = self.expect_workflow_creation(QueueVideoWorkflow)
         self.workflow.to_QUEUEING()
         queue_workflow.start.assert_called_once()
         self.raise_event(self.workflow, queue_workflow.Completed, queue_workflow.id)
@@ -223,7 +223,7 @@ class StreamPlaylistWorkflowTest(WorkflowTestCase):
 
     def test_starting_to_queueing_from_completed(self):
         workflow = self.make_test_workflow()
-        play_workflow = self.expect_workflow_creation(StreamVideoWorkflow)
+        (play_workflow,) = self.expect_workflow_creation(StreamVideoWorkflow)
         workflow.to_STARTING(None)
 
         self.expect_workflow_creation(QueueVideoWorkflow)
@@ -232,49 +232,49 @@ class StreamPlaylistWorkflowTest(WorkflowTestCase):
 
     def test_starting_to_starting_from_aborted(self):
         workflow = self.make_test_workflow()
-        play_workflow = self.expect_workflow_creation(StreamVideoWorkflow)
+        play_workflows = self.expect_workflow_creation(StreamVideoWorkflow, 2)
         workflow.to_STARTING(None)
-        self.raise_event(workflow, play_workflow.Aborted, workflow.id)
+        self.raise_event(workflow, play_workflows[0].Aborted, workflow.id)
         self.assertTrue(workflow.is_STARTING())
 
     def test_starting_to_completed_from_completed(self):
         workflow = self.make_test_workflow(video_count=1)
-        play_workflow = self.expect_workflow_creation(StreamVideoWorkflow)
+        (play_workflow,) = self.expect_workflow_creation(StreamVideoWorkflow)
         workflow.to_STARTING(None)
         self.raise_event(workflow, play_workflow.Completed, workflow.id)
         self.assertTrue(workflow.is_COMPLETED())
 
     def test_starting_to_completed_from_aborted(self):
         workflow = self.make_test_workflow(video_count=1)
-        play_workflow = self.expect_workflow_creation(StreamVideoWorkflow)
+        (play_workflow,) = self.expect_workflow_creation(StreamVideoWorkflow)
         workflow.to_STARTING(None)
         self.raise_event(workflow, play_workflow.Aborted, workflow.id)
         self.assertTrue(workflow.is_COMPLETED())
 
     def test_queueing_to_queueing_from_completed(self):
         workflow = self.make_test_workflow()
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        queue_workflows = self.expect_workflow_creation(QueueVideoWorkflow, 2)
         workflow.to_QUEUEING(None)
-        self.raise_event(workflow, queue_workflow.Completed, workflow.id)
+        self.raise_event(workflow, queue_workflows[0].Completed, workflow.id)
         self.assertTrue(workflow.is_QUEUEING())
 
     def test_queueing_to_queueing_from_aborted(self):
         workflow = self.make_test_workflow()
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        queue_workflows = self.expect_workflow_creation(QueueVideoWorkflow, 2)
         workflow.to_QUEUEING(None)
-        self.raise_event(workflow, queue_workflow.Aborted, workflow.id)
+        self.raise_event(workflow, queue_workflows[0].Aborted, workflow.id)
         self.assertTrue(workflow.is_QUEUEING())
 
     def test_queueing_to_completed_from_completed(self):
         workflow = self.make_test_workflow(video_count=1)
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        (queue_workflow,) = self.expect_workflow_creation(QueueVideoWorkflow)
         workflow.to_QUEUEING(None)
         self.raise_event(workflow, queue_workflow.Completed, workflow.id)
         self.assertTrue(workflow.is_COMPLETED())
 
     def test_queueing_to_completed_from_aborted(self):
         workflow = self.make_test_workflow(video_count=1)
-        queue_workflow = self.expect_workflow_creation(QueueVideoWorkflow)
+        (queue_workflow,) = self.expect_workflow_creation(QueueVideoWorkflow)
         workflow.to_QUEUEING(None)
         self.raise_event(workflow, queue_workflow.Aborted, workflow.id)
         self.assertTrue(workflow.is_COMPLETED())

--- a/test/unit/app/workflow/test_root.py
+++ b/test/unit/app/workflow/test_root.py
@@ -1,0 +1,58 @@
+from pathlib import Path
+from test.shared.infra.data.facade_mock import DataFacadeMock
+from test.shared.infra.facade_mock import InfraFacadeMock
+from unittest.mock import Mock
+
+from OpenCast.app.workflow.root import RootWorkflow
+from OpenCast.app.workflow.video import VideoWorkflow
+
+from .util import WorkflowTestCase
+
+
+class RootWorkflowTest(WorkflowTestCase):
+    def setUp(self):
+        super().setUp()
+        self.video_repo = Mock()
+        self.infra_facade = InfraFacadeMock()
+        self.data_facade = DataFacadeMock()
+
+        self.file_service = Mock()
+        self.infra_facade.service_factory.make_file_service.return_value = (
+            self.file_service
+        )
+
+        self.workflow = self.make_workflow(
+            RootWorkflow, self.infra_facade, self.data_facade
+        )
+
+    def test_initial(self):
+        self.assertTrue(self.workflow.is_INITIAL())
+
+    def test_init_to_loading(self):
+        self.file_service.list_directory.return_value = []
+        self.workflow.start()
+
+    def test_loading_to_running(self):
+        local_files = [
+            Mock(),
+            Mock(),
+        ]
+        self.file_service.list_directory.return_value = local_files
+        for file in local_files:
+            file.is_file.return_value = True
+
+        wf_mocks = self.expect_workflow_creation(VideoWorkflow, 2)
+
+        self.workflow.to_LOADING()
+
+        for mock in wf_mocks:
+            mock.start.assert_called_once()
+        self.assertTrue(self.workflow.is_RUNNING())
+
+    def test_running_to_aborted(self):
+        def raise_exception(*_):
+            raise RuntimeError("server stopped")
+
+        self.infra_facade.server.start.side_effect = raise_exception
+        self.workflow.to_RUNNING()
+        self.assertTrue(self.workflow.is_ABORTED())

--- a/test/unit/app/workflow/util.py
+++ b/test/unit/app/workflow/util.py
@@ -1,4 +1,3 @@
-import uuid
 from test.shared.app.facade_mock import AppFacadeMock
 from test.util import TestCase
 from unittest.mock import Mock
@@ -19,7 +18,7 @@ class WorkflowTestCase(TestCase):
         self.app_facade.workflow_manager.start.side_effect = start_workflow
 
     def make_workflow(self, workflow_cls, *args, **kwargs):
-        return workflow_cls(uuid.uuid4(), self.app_facade, *args, **kwargs)
+        return workflow_cls(IdentityService.random(), self.app_facade, *args, **kwargs)
 
     def expect_dispatch(self, cmd_cls, model_id, *args, **kwargs):
         cmd_id = IdentityService.id_command(cmd_cls, model_id)

--- a/test/unit/app/workflow/util.py
+++ b/test/unit/app/workflow/util.py
@@ -33,11 +33,16 @@ class WorkflowTestCase(TestCase):
         event = evt_cls(*args, **kwargs)
         getattr(workflow, name_handler_method(evt_cls))(event)
 
-    def expect_workflow_creation(self, wf_cls):
-        wf_mock = Mock()
-        wf_mock.Completed = wf_cls.Completed
-        wf_mock.Aborted = wf_cls.Aborted
+    def expect_workflow_creation(self, wf_cls, times=1):
+        mocks = []
+        for i in range(times):
+            wf_mock = Mock()
+            wf_mock.Completed = wf_cls.Completed
+            wf_mock.Aborted = wf_cls.Aborted
+            mocks.append(wf_mock)
+
         getattr(
             self.app_facade.workflow_factory, name_factory_method(wf_cls)
-        ).return_value = wf_mock
-        return wf_mock
+        ).side_effect = mocks
+
+        return tuple(mocks)

--- a/test/unit/domain/event/test_dispatcher.py
+++ b/test/unit/domain/event/test_dispatcher.py
@@ -1,14 +1,14 @@
 from test.util import TestCase
 from unittest.mock import Mock
-from uuid import uuid4
 
 from OpenCast.domain.event.dispatcher import EventDispatcher
+from OpenCast.domain.service.identity import IdentityService
 
 
 class EventDispatcherTest(TestCase):
     def setUp(self):
         self.dispatcher = EventDispatcher()
-        self.cmd_id = uuid4()
+        self.cmd_id = IdentityService.random()
         self.evt = Mock()
         self.evt.id = self.cmd_id
         self.handler = Mock()
@@ -21,7 +21,9 @@ class EventDispatcherTest(TestCase):
     def test_observe_event_by_id(self):
         self.dispatcher.observe_result(self.cmd_id, {type(self.evt): self.handler})
         # Unrelated event should not call the handler
-        self.dispatcher.observe_result(uuid4(), {type(self.evt): self.handler})
+        self.dispatcher.observe_result(
+            IdentityService.random(), {type(self.evt): self.handler}
+        )
         self.dispatcher.dispatch(self.evt)
         self.handler.assert_called_once_with(self.evt)
 

--- a/test/unit/domain/service/test_subtitle.py
+++ b/test/unit/domain/service/test_subtitle.py
@@ -8,43 +8,43 @@ from OpenCast.domain.service.subtitle import SubtitleService
 
 class SubtitleServiceTest(TestCase):
     def setUp(self):
-        self.downloader = Mock()
         self.lang = config["subtitle.language"]
 
         self.video = Mock()
         path_mock = MagicMock()
         self.video.path = path_mock
 
-        self.service = SubtitleService(self.downloader)
+        self.file_service = Mock()
+        self.downloader = Mock()
+        self.service = SubtitleService(self.file_service, self.downloader)
 
-    def expect_from_disk(self, files):
-        parent_mock = Mock()
-        self.video.path.parents.__getitem__.return_value = parent_mock
-        self.video.path.with_suffix.return_value = Path("/tmp/video.srt")
-        parent_mock.glob.return_value = [Path(file) for file in files]
+    def expect_from_disk(self, file, disk_files):
+        self.video.path.with_suffix.return_value = Path(file)
+        self.file_service.list_directory.return_value = [
+            Path(file) for file in disk_files
+        ]
 
     def expect_from_source(self, file):
         self.video.from_disk.return_value = False
         self.downloader.download_subtitle.return_value = file
 
     def test_load_from_disk(self):
-        found_sub = "/tmp/video.srt"
-        self.expect_from_disk([found_sub])
+        disk_subtitle = "/tmp/video.srt"
+        self.expect_from_disk(disk_subtitle, [disk_subtitle])
 
         subtitle = self.service.fetch_subtitle(self.video, self.lang)
-        self.assertEqual(found_sub, subtitle)
+        self.assertEqual(disk_subtitle, subtitle)
 
     def test_download_from_source(self):
-        self.expect_from_disk([])
-
         source_subtitle = "/tmp/source.vtt"
+        self.expect_from_disk("/tmp/source.srt", [])
         self.expect_from_source(source_subtitle)
 
         subtitle = self.service.fetch_subtitle(self.video, self.lang)
         self.assertEqual(Path(source_subtitle), subtitle)
 
     def test_fetch_online(self):
-        self.expect_from_disk([])
+        self.expect_from_disk("/tmp/video.srt", [])
         self.expect_from_source(None)
         subtitle = self.service.fetch_subtitle(self.video, self.lang)
         self.assertEqual(None, subtitle)

--- a/test/unit/infra/data/repo/test_memory.py
+++ b/test/unit/infra/data/repo/test_memory.py
@@ -64,8 +64,15 @@ class MemoryRepoTest(TestCase):
     def test_list(self):
         self.repo.create(self.entity)
         entity_list = self.repo.list()
-        self.assertEqual(1, len(entity_list))
+        self.assertEqual([self.entity], entity_list)
         self.assertNotEqual(id(self.entity), id(entity_list[0]))
+
+    def test_list_filtered(self):
+        entities = [Entity(IdentityService.random()) for i in range(5)]
+        for entity in entities:
+            self.repo.create(entity)
+        entity_list = self.repo.list([entities[0].id, entities[2].id])
+        self.assertEqual([entities[0], entities[2]], entity_list)
 
     def test_get(self):
         self.repo.create(self.entity)

--- a/test/unit/infra/data/repo/test_memory.py
+++ b/test/unit/infra/data/repo/test_memory.py
@@ -1,8 +1,7 @@
 from test.util import TestCase
-from unittest.mock import Mock
-from uuid import uuid4
 
 from OpenCast.domain.model.entity import Entity
+from OpenCast.domain.service.identity import IdentityService
 from OpenCast.infra.data.repo.error import RepoError
 from OpenCast.infra.data.repo.memory import MemoryRepo
 
@@ -10,7 +9,7 @@ from OpenCast.infra.data.repo.memory import MemoryRepo
 class MemoryRepoTest(TestCase):
     def setUp(self):
         self.repo = MemoryRepo()
-        self.entity = Entity(uuid4())
+        self.entity = Entity(IdentityService.random())
 
     def test_create(self):
         self.repo.create(self.entity)

--- a/test/unit/infra/media/test_parser.py
+++ b/test/unit/infra/media/test_parser.py
@@ -60,3 +60,19 @@ class VideoParserTest(TestCase):
             f"Can't parse streams from '{video_path}', status='{status}'",
             str(ctx.exception),
         )
+
+    def test_parse_streams_no_stream(self):
+        video_path = "/tmp/source.mp4"
+        media = Mock()
+        self.vlc.media_new.return_value = media
+        media.parse_with_options.return_value = 0
+        media.get_parsed_status.return_value = MediaParsedStatus.done
+        media.is_parsed.return_value = 1
+        media.tracks_get.return_value = None
+
+        with self.assertRaises(VideoParsingError) as ctx:
+            self.parser.parse_streams(video_path)
+        self.assertEqual(
+            f"No stream found for '{video_path}'",
+            str(ctx.exception),
+        )

--- a/test/unit/infra/service/test_file.py
+++ b/test/unit/infra/service/test_file.py
@@ -1,0 +1,22 @@
+from test.util import TestCase
+from unittest.mock import Mock
+
+from OpenCast.infra.service.file import FileService
+
+
+class FileServiceTest(TestCase):
+    def setUp(self):
+        self.service = FileService()
+
+    def test_list_directory(self):
+        path = Mock()
+        files = [Mock() for i in range(5)]
+        expected = []
+        for i, file in enumerate(files):
+            file.is_file.return_value = i % 2
+            if file.is_file():
+                expected.append(file)
+        path.glob.return_value = files
+
+        self.assertEqual(expected, self.service.list_directory(path, "*"))
+        path.glob.assert_called_with("*")

--- a/webapp/src/components/video_list.js
+++ b/webapp/src/components/video_list.js
@@ -65,10 +65,10 @@ function VideoList() {
   };
 
   const listVideos = () => {
-    videoAPI
-      .list()
+    playerAPI
+      .get()
       .then((response) => {
-        setVideos(response.data);
+        setVideos(response.data.queue);
       })
       .catch((error) => console.log(error));
   };


### PR DESCRIPTION
Implement the first iteration of the library.
While files are currently loaded from the download directory it is planned to add a database so that media entries would be fetched from the DB.

 - Implement the root workflow of the application
 - Fix workflow manager deadlock
 - Fix media parser not handling non-media files